### PR TITLE
PDF出力時の不具合改修

### DIFF
--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -113,6 +113,11 @@ const outputPdf = (data) => {
   </div>`;
   const docDefinition = { 
     pageSize: 'A4',
+    footer: function (currentPage, pageCount) {
+      return [
+        { text: `- ${currentPage} -`, alignment: 'center', fontSize: 10 }
+      ]
+    },
     defaultStyle: {
       font: "ipagp",
       fontSize: 11,

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -4,11 +4,11 @@ import htmlToPdfmake from "html-to-pdfmake";
 
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 pdfMake.fonts = {
-  GenShinGothic: {
-    normal: "GenShinGothic-Normal-Sub.ttf",
-    bold: "GenShinGothic-Normal-Sub.ttf",
-    italics: "GenShinGothic-Normal-Sub.ttf",
-    bolditalics: "GenShinGothic-Normal-Sub.ttf",
+  ipagp: {
+    normal: "ipagp.ttf",
+    bold: "ipagp.ttf",
+    italics: "ipagp.ttf",
+    bolditalics: "ipagp.ttf",
   }
 };
 
@@ -114,7 +114,7 @@ const outputPdf = (data) => {
   const docDefinition = { 
     pageSize: 'A4',
     defaultStyle: {
-      font: "GenShinGothic",
+      font: "ipagp",
       fontSize: 11,
     },
     styles: {


### PR DESCRIPTION
#1 

源信ゴシックが全角記号非対応のためIPAフォントへ変更
